### PR TITLE
Add .gitattributes to recognize .gd files as GDScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gd linguist-language=GDScript


### PR DESCRIPTION
This makes GitHub detect this repository's language as GDScript instead of GAP.