### PR TITLE
Remove randomize() call from getRandomInt()

### DIFF
--- a/uuid.gd
+++ b/uuid.gd
@@ -5,9 +5,6 @@ extends Node
 const MODULO_8_BIT = 256
 
 static func getRandomInt():
-  # Randomize every time to minimize the risk of collisions
-  randomize()
-
   return randi() % MODULO_8_BIT
 
 static func uuidbin():


### PR DESCRIPTION
From the [documents](https://docs.godotengine.org/en/latest/tutorials/math/random_number_generation.html#the-randomize-method):

> This method should be called only once when your project starts to initialize the random seed. 

The [PRNG that Godot uses](https://www.pcg-random.org/) is already robust against collisions without calling randomize() over and over; in fact, as far as I can tell, given [the way seeding works](https://github.com/godotengine/godot/blob/8f7f5846397297fff6e8a08f89bc60ce658699cc/thirdparty/misc/pcg.cpp#L18), it's actually *more* likely to cause a collision to call randomize() every time, although it's *very, very* negligible either way. Regardless, it's explicitly discouraged and reduces performance, which seems to be not the goal here.