### PR TITLE
Performance improvements, capability extention, Godot 4.0 compatibility

### DIFF
--- a/test.gd
+++ b/test.gd
@@ -13,15 +13,19 @@ func benchmark_raw():
 
   var uuids := []
   var begin = Time.get_unix_time_from_system()
-
-  for i in range(NUMBER_OF_TESTS):
+  
+  var test_number := 0
+  while test_number < NUMBER_OF_TESTS:
+    
     uuid_util.v4()
+    
+    test_number += 1
     
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   test_number / duration,
+   (duration / test_number) * 1000000,
    duration
   ])
   print('Benchmark done')
@@ -33,14 +37,18 @@ func benchmark_raw_rng():
   var uuids := []
   var begin = Time.get_unix_time_from_system()
 
-  for i in range(NUMBER_OF_TESTS):
+  var test_number = 0
+  while test_number < NUMBER_OF_TESTS:
+    
     uuid_util.v4_rng(rng)
     
+    test_number += 1
+  
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   test_number / duration,
+   (duration / test_number) * 1000000,
    duration
   ])
   print('Benchmark done')
@@ -50,14 +58,18 @@ func benchmark_obj():
 
   var begin = Time.get_unix_time_from_system()
 
-  for i in range(NUMBER_OF_TESTS):
+  var test_number = 0
+  while test_number < NUMBER_OF_TESTS:
+  
     uuid_util.new().free()  # immediately freeing does not seem to add much overhead
+    
+    test_number += 1
 
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   test_number / duration,
+   (duration / test_number) * 1000000,
    duration
   ])
   print('Benchmark done')
@@ -68,14 +80,18 @@ func benchmark_obj_rng():
   var rng = RandomNumberGenerator.new()
   var begin = Time.get_unix_time_from_system()
 
-  for i in range(NUMBER_OF_TESTS):
+  var test_number = 0
+  while test_number < NUMBER_OF_TESTS:
+    
     uuid_util.new(rng).free()  # immediately freeing does not seem to add much overhead
 
+    test_number += 1
+  
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   test_number / duration,
+   (duration / test_number) * 1000000,
    duration
   ])
   print('Benchmark done')
@@ -83,8 +99,10 @@ func benchmark_obj_rng():
 func benchmark_obj_to_dict():
   print('Setting up benchmark ...')
   var uuids = []
-  for i in range(NUMBER_OF_OBJECTS):
+  var index = 0
+  while index < NUMBER_OF_OBJECTS:
     uuids.append(uuid_util.new())
+    index += 1
 
   print('Benchmarking ...')
   var begin = Time.get_unix_time_from_system()
@@ -95,8 +113,8 @@ func benchmark_obj_to_dict():
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   uuids.size() / duration,
+   (duration / uuids.size()) * 1000000,
    duration
   ])
   print('Cleaning up ...')
@@ -107,8 +125,10 @@ func benchmark_obj_to_dict():
 func benchmark_obj_to_str():
   print('Setting up benchmark ...')
   var uuids = []
-  for i in range(NUMBER_OF_OBJECTS):
+  var index = 0
+  while index < NUMBER_OF_OBJECTS:
     uuids.append(uuid_util.new())
+    index += 1
 
   print('Benchmarking ...')
   var begin = Time.get_unix_time_from_system()
@@ -119,8 +139,8 @@ func benchmark_obj_to_str():
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   uuids.size() / duration,
+   (duration / uuids.size()) * 1000000,
    duration
   ])
   print('Cleaning up ...')
@@ -131,23 +151,35 @@ func benchmark_obj_to_str():
 func benchmark_comp_raw():
   print('Setting up benchmark ...')
   var uuids = []
-  for i in range(NUMBER_OF_TESTS*2):
+  var index = 0
+  while index < NUMBER_OF_OBJECTS * 2:
     uuids.append(uuid_util.v4())
+    index += 1
+  
+  var test = 0
+  var max_tests = uuids.size() - 1
+  var collisions = 0
+
   print('Benchmarking ...')
   var begin = Time.get_unix_time_from_system()
 
-  for i in range(NUMBER_OF_TESTS):
-    var uuid1 = uuids[i*2]
-    var uuid2 = uuids[i*2+1]
+  while test < max_tests:
+    var uuid1 = uuids[test]
+    var uuid2 = uuids[test + 1]
     
     if uuid1 == uuid2:
-      print("uh-oh")
+      collisions += 1
+      print("Test #%s detected collision (%s = %s)" % [test, uuid1, uuid2])
+      
+    test += 1
 
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
+  print("%s collisions detected" % collisions)
+  print("%s total comparison operations" % test)
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   test / duration,
+   (duration / test) * 1000000,
    duration
   ])
   print('Benchmark done')
@@ -155,23 +187,35 @@ func benchmark_comp_raw():
 func benchmark_comp_obj():
   print('Setting up benchmark ...')
   var uuids = []
-  for i in range(NUMBER_OF_OBJECTS*2):
+  var index = 0
+  while index < NUMBER_OF_OBJECTS * 2:
     uuids.append(uuid_util.new())
+    index += 1
+    
+  var test = 0
+  var max_tests = uuids.size() - 1
+  var collisions = 0
+    
   print('Benchmarking ...')
   var begin = Time.get_unix_time_from_system()
 
-  for i in range(NUMBER_OF_OBJECTS):
-    var uuid1 = uuids[i*2]
-    var uuid2 = uuids[i*2+1]
+  while test < max_tests:
+    var uuid1 = uuids[test]
+    var uuid2 = uuids[test + 1]
     
     if uuid1.is_equal(uuid2):
-      print("uh-oh")
+      collisions += 1
+      print("Test #%s detected collision (%s = %s)" % [test, uuid1, uuid2])
+      
+    test += 1
 
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
+  print("%s collisions detected" % collisions)
+  print("%s total comparison operations" % test)
   print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
-   NUMBER_OF_TESTS / duration,
-   (duration / NUMBER_OF_TESTS) * 1000000,
+   test / duration,
+   (duration / test) * 1000000,
    duration
   ])
   print('Cleaning up ...')
@@ -185,7 +229,8 @@ func detect_collision():
   var number_of_collision = 0
   var generated_uuid = {}
 
-  for i in range(NUMBER_OF_TESTS):
+  var index = 0
+  while index < NUMBER_OF_TESTS:
     var key = uuid_util.v4()
 
     if generated_uuid.has(key):
@@ -193,6 +238,8 @@ func detect_collision():
 
     else:
       generated_uuid[key] = true
+      
+    index += 1
 
   print('Number of collision: %s' % [ number_of_collision ])
   print('Collision detection done')  
@@ -205,7 +252,8 @@ func detect_collision_with_rng():
   var number_of_collision = 0
   var generated_uuid = {}
 
-  for i in range(NUMBER_OF_TESTS):
+  var index = 0
+  while index < NUMBER_OF_TESTS:
     var key = uuid_util.v4_rng(rng)
 
     if generated_uuid.has(key):
@@ -213,6 +261,8 @@ func detect_collision_with_rng():
 
     else:
       generated_uuid[key] = true
+      
+    index += 1
 
   print('Number of collision: %s' % [ number_of_collision ])
   print('Collision detection done')  

--- a/test.gd
+++ b/test.gd
@@ -92,11 +92,19 @@ func benchmark_obj_to_str():
   print('Benchmark done')
   
 func benchmark_comp_raw():
+  print('Setting up benchmark ...')
+  var uuids = []
+  for i in range(NUMBER_OF_TESTS*2):
+    uuids.append(uuid_util.v4())
   print('Benchmarking ...')
   var begin = Time.get_unix_time_from_system()
 
   for i in range(NUMBER_OF_TESTS):
-    uuid_util.v4() == uuid_util.v4()
+    var uuid1 = uuids[i*2]
+    var uuid2 = uuids[i*2+1]
+    
+    if uuid1 == uuid2:
+      print("uh-oh")
 
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
@@ -119,7 +127,8 @@ func benchmark_comp_obj():
     var uuid1 = uuids[i*2]
     var uuid2 = uuids[i*2+1]
     
-    uuid1.is_equal(uuid2)
+    if uuid1.is_equal(uuid2):
+      print("uh-oh")
 
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 

--- a/test.gd
+++ b/test.gd
@@ -90,6 +90,48 @@ func benchmark_obj_to_str():
   for uuid in uuids:
     uuid.free()
   print('Benchmark done')
+  
+func benchmark_comp_raw():
+  print('Benchmarking ...')
+  var begin = Time.get_unix_time_from_system()
+
+  for i in range(NUMBER_OF_TESTS):
+    uuid_util.v4() == uuid_util.v4()
+
+  var duration = 1.0 * Time.get_unix_time_from_system() - begin
+
+  print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
+   NUMBER_OF_TESTS / duration,
+   (duration / NUMBER_OF_TESTS) * 1000000,
+   duration
+  ])
+  print('Benchmark done')
+  
+func benchmark_comp_obj():
+  print('Setting up benchmark ...')
+  var uuids = []
+  for i in range(NUMBER_OF_OBJECTS*2):
+    uuids.append(uuid_util.new())
+  print('Benchmarking ...')
+  var begin = Time.get_unix_time_from_system()
+
+  for i in range(NUMBER_OF_OBJECTS):
+    var uuid1 = uuids[i*2]
+    var uuid2 = uuids[i*2+1]
+    
+    uuid1.is_equal(uuid2)
+
+  var duration = 1.0 * Time.get_unix_time_from_system() - begin
+
+  print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
+   NUMBER_OF_TESTS / duration,
+   (duration / NUMBER_OF_TESTS) * 1000000,
+   duration
+  ])
+  print('Cleaning up ...')
+  for uuid in uuids:
+    uuid.free()
+  print('Benchmark done')
 
 func detect_collision():
   print('Detecting collision ...')
@@ -144,5 +186,11 @@ func _init():
   
   print("\n---------------- Obj to string ----------------")
   benchmark_obj_to_str()
+  
+  print("\n----------------  Compare raw  ----------------")
+  benchmark_comp_raw()
+  
+  print("\n----------------  Compare obj  ----------------")
+  benchmark_comp_obj()
   
   quit()

--- a/test.gd
+++ b/test.gd
@@ -26,6 +26,25 @@ func benchmark_raw():
   ])
   print('Benchmark done')
   
+func benchmark_raw_rng():
+  print('Benchmarking ...')
+
+  var rng = RandomNumberGenerator.new()
+  var uuids := []
+  var begin = Time.get_unix_time_from_system()
+
+  for i in range(NUMBER_OF_TESTS):
+    uuid_util.v4_rng(rng)
+    
+  var duration = 1.0 * Time.get_unix_time_from_system() - begin
+
+  print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
+   NUMBER_OF_TESTS / duration,
+   (duration / NUMBER_OF_TESTS) * 1000000,
+   duration
+  ])
+  print('Benchmark done')
+  
 func benchmark_obj():
   print('Benchmarking ...')
 
@@ -33,6 +52,24 @@ func benchmark_obj():
 
   for i in range(NUMBER_OF_TESTS):
     uuid_util.new().free()  # immediately freeing does not seem to add much overhead
+
+  var duration = 1.0 * Time.get_unix_time_from_system() - begin
+
+  print('uuid/sec: %.02f   avg time: %.4fus   total time: %.2fs' % [
+   NUMBER_OF_TESTS / duration,
+   (duration / NUMBER_OF_TESTS) * 1000000,
+   duration
+  ])
+  print('Benchmark done')
+  
+func benchmark_obj_rng():
+  print('Benchmarking ...')
+
+  var rng = RandomNumberGenerator.new()
+  var begin = Time.get_unix_time_from_system()
+
+  for i in range(NUMBER_OF_TESTS):
+    uuid_util.new(rng).free()  # immediately freeing does not seem to add much overhead
 
   var duration = 1.0 * Time.get_unix_time_from_system() - begin
 
@@ -187,8 +224,14 @@ func _init():
   print("\n----------------      Raw      ----------------")
   benchmark_raw()
   
+  print("\n---------------- Raw with rng  ----------------")
+  benchmark_raw_rng()
+  
   print("\n---------------- Simple object ----------------")
   benchmark_obj()
+  
+  print("\n---------------- Obj with rng  ----------------")
+  benchmark_obj_rng()
   
   print("\n----------------  Obj to dict  ----------------")
   benchmark_obj_to_dict()

--- a/uuid.gd
+++ b/uuid.gd
@@ -108,3 +108,23 @@ func as_string() -> String:
     # node
     _uuid[10], _uuid[11], _uuid[12], _uuid[13], _uuid[14], _uuid[15]
   ]
+  
+func is_equal(other) -> bool:
+  return (
+    _uuid[0 ] == other._uuid[0 ] and \
+    _uuid[1 ] == other._uuid[1 ] and \
+    _uuid[2 ] == other._uuid[2 ] and \
+    _uuid[3 ] == other._uuid[3 ] and \
+    _uuid[4 ] == other._uuid[4 ] and \
+    _uuid[5 ] == other._uuid[5 ] and \
+    _uuid[6 ] == other._uuid[6 ] and \
+    _uuid[7 ] == other._uuid[7 ] and \
+    _uuid[8 ] == other._uuid[8 ] and \
+    _uuid[9 ] == other._uuid[9 ] and \
+    _uuid[10] == other._uuid[10] and \
+    _uuid[11] == other._uuid[11] and \
+    _uuid[12] == other._uuid[12] and \
+    _uuid[13] == other._uuid[13] and \
+    _uuid[14] == other._uuid[14] and \
+    _uuid[15] == other._uuid[15]
+  )

--- a/uuid.gd
+++ b/uuid.gd
@@ -67,9 +67,15 @@ static func v4_rng(rng: RandomNumberGenerator):
   
 var _uuid: Array
 
-func _init() -> void:
-  _uuid = uuidbin()
-  
+class _sentinel extends RandomNumberGenerator:
+  pass
+
+func _init(rng: RandomNumberGenerator = _sentinel.new()) -> void:
+  if rng is _sentinel:
+    _uuid = uuidbin()
+  else:
+    _uuid = uuidbinrng(rng)
+
 func as_array() -> Array:
   return _uuid.duplicate()
 

--- a/uuid.gd
+++ b/uuid.gd
@@ -67,14 +67,8 @@ static func v4_rng(rng: RandomNumberGenerator):
   
 var _uuid: Array
 
-class _sentinel extends RandomNumberGenerator:
-  pass
-
-func _init(rng: RandomNumberGenerator = _sentinel.new()) -> void:
-  if rng is _sentinel:
-    _uuid = uuidbin()
-  else:
-    _uuid = uuidbinrng(rng)
+func _init(rng := RandomNumberGenerator.new()) -> void:
+  _uuid = uuidbinrng(rng)
 
 func as_array() -> Array:
   return _uuid.duplicate()

--- a/uuid.gd
+++ b/uuid.gd
@@ -1,22 +1,26 @@
 # Note: The code might not be as pretty it could be, since it's written
 # in a way that maximizes performance. Methods are inlined and loops are avoided.
-extends Node
+extends Object
 
-const MODULO_8_BIT = 256
-
-static func getRandomInt():
-  # Randomize every time to minimize the risk of collisions
-  randomize()
-
-  return randi() % MODULO_8_BIT
+const BYTE_MASK: int = 0b11111111
 
 static func uuidbin():
+  randomize()
   # 16 random bytes with the bytes on index 6 and 8 modified
   return [
-    getRandomInt(), getRandomInt(), getRandomInt(), getRandomInt(),
-    getRandomInt(), getRandomInt(), ((getRandomInt()) & 0x0f) | 0x40, getRandomInt(),
-    ((getRandomInt()) & 0x3f) | 0x80, getRandomInt(), getRandomInt(), getRandomInt(),
-    getRandomInt(), getRandomInt(), getRandomInt(), getRandomInt(),
+    randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK,
+    randi() & BYTE_MASK, randi() & BYTE_MASK, ((randi() & BYTE_MASK) & 0x0f) | 0x40, randi() & BYTE_MASK,
+    ((randi() & BYTE_MASK) & 0x3f) | 0x80, randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK,
+    randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK,
+  ]
+
+static func uuidbinrng(rng: RandomNumberGenerator):
+  rng.randomize()
+  return [
+    rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
+    rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, ((rng.randi() & BYTE_MASK) & 0x0f) | 0x40, rng.randi() & BYTE_MASK,
+    ((rng.randi() & BYTE_MASK) & 0x3f) | 0x80, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
+    rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
   ]
 
 static func v4():
@@ -38,4 +42,69 @@ static func v4():
 
     # clock
     b[10], b[11], b[12], b[13], b[14], b[15]
+  ]
+  
+static func v4_rng(rng: RandomNumberGenerator):
+  # 16 random bytes with the bytes on index 6 and 8 modified
+  var b = uuidbinrng(rng)
+
+  return '%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x' % [
+    # low
+    b[0], b[1], b[2], b[3],
+
+    # mid
+    b[4], b[5],
+
+    # hi
+    b[6], b[7],
+
+    # clock
+    b[8], b[9],
+
+    # clock
+    b[10], b[11], b[12], b[13], b[14], b[15]
+  ]
+  
+var _uuid: Array
+
+func _init() -> void:
+  _uuid = uuidbin()
+  
+func as_array() -> Array:
+  return _uuid.duplicate()
+
+func as_dict(big_endian := true) -> Dictionary:
+  if big_endian:
+    return {
+      "low"  : (_uuid[0]  << 24) + (_uuid[1]  << 16) + (_uuid[2]  << 8 ) + _uuid[3],
+      "mid"  : (_uuid[4]  << 8 ) +  _uuid[5],
+      "hi"   : (_uuid[6]  << 8 ) +  _uuid[7],
+      "clock": (_uuid[8]  << 8 ) +  _uuid[9],
+      "node" : (_uuid[10] << 40) + (_uuid[11] << 32) + (_uuid[12] << 24) + (_uuid[13] << 16) + (_uuid[14] << 8 ) +  _uuid[15]
+    }
+  else:
+    return {
+      "low"  : _uuid[0]          + (_uuid[1]  << 8 ) + (_uuid[2]  << 16) + (_uuid[3]  << 24),
+      "mid"  : _uuid[4]          + (_uuid[5]  << 8 ),
+      "hi"   : _uuid[6]          + (_uuid[7]  << 8 ),
+      "clock": _uuid[8]          + (_uuid[9]  << 8 ),
+      "node" : _uuid[10]         + (_uuid[11] << 8 ) + (_uuid[12] << 16) + (_uuid[13] << 24) + (_uuid[14] << 32) + (_uuid[15] << 40)
+    }
+    
+func as_string() -> String:
+  return '%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x' % [
+    # low
+    _uuid[0], _uuid[1], _uuid[2], _uuid[3],
+
+    # mid
+    _uuid[4], _uuid[5],
+
+    # hi
+    _uuid[6], _uuid[7],
+
+    # clock
+    _uuid[8], _uuid[9],
+
+    # node
+    _uuid[10], _uuid[11], _uuid[12], _uuid[13], _uuid[14], _uuid[15]
   ]

--- a/uuid.gd
+++ b/uuid.gd
@@ -1,6 +1,6 @@
 # Note: The code might not be as pretty it could be, since it's written
 # in a way that maximizes performance. Methods are inlined and loops are avoided.
-extends Object
+extends Node
 
 const BYTE_MASK: int = 0b11111111
 
@@ -82,7 +82,7 @@ func as_array() -> Array:
 func as_dict(big_endian := true) -> Dictionary:
   if big_endian:
     return {
-      "low"  : (_uuid[0]  << 24) + (_uuid[1]  << 16) + (_uuid[2]  << 8 ) + _uuid[3],
+      "low"  : (_uuid[0]  << 24) + (_uuid[1]  << 16) + (_uuid[2]  << 8 ) +  _uuid[3],
       "mid"  : (_uuid[4]  << 8 ) +  _uuid[5],
       "hi"   : (_uuid[6]  << 8 ) +  _uuid[7],
       "clock": (_uuid[8]  << 8 ) +  _uuid[9],


### PR DESCRIPTION
Improved performance by replacing modulo operator with bitwise and. Modulo basically performs a division and thus is not the best way to just get lower 8 bits of an int. 

And randomizing on every RNG call is a bit too paranoid in my opinion and should not affect probability of collisions. Randomization is time based and so randomizing between generations of UUIDs is enough. So far in my testing I had 0 collisions.

Also replaced `OS.get_ticks_msec()` with `Time.get_unix_time_from_system()`. `OS.get_ticks_msec()` was removed in 4.0. Also `Time.get_unix_time_from_system()` returns a float and thus allows for greater precision than `OS.get_ticks_msec()` (I think, not sure how accurately different systems calculate this number, but it seems fine for me).

Additionally, I created methods for creating UUIDs with `RandomNumberGenerator` instances. But it seems that using 

And lastly, `UUID` can now be instanced and managed as an object. This might be useful with code that utilizes OOP paradigms. Also, the comparison between two UUIDs is a bit faster when using `UUID` objects and `is_equal()` method rather than directly comparing string UUIDs.

However, it should be noted that instancing objects in Godot has a huge overhead. On my computer, creating a raw UUID is about 20 times faster than instancing `UUID` class. (5 microseconds vs. 100 microseconds).
