### PR TITLE
Prevent randomisation of uuid when using rng

### DIFF
--- a/uuid.gd
+++ b/uuid.gd
@@ -15,7 +15,6 @@ static func uuidbin():
   ]
 
 static func uuidbinrng(rng: RandomNumberGenerator):
-  rng.randomize()
   return [
     rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
     rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, ((rng.randi() & BYTE_MASK) & 0x0f) | 0x40, rng.randi() & BYTE_MASK,


### PR DESCRIPTION
Which allows for deterministic creation of uuid, I think this was just a bug?

```gdscript
func get_hash(item: Dictionary) -> int:
	var keys = item.values()
	keys.sort()
	return hash("_".join(keys))


func get_rng(item: Dictionary) -> RandomNumberGenerator:
	var rng = RandomNumberGenerator.new()
	rng.set_seed(get_hash(item))
	return rng


func _init(item: Dictionary) -> void:
	# The following ID will always be the same (unless the data changes)
	self.id = preload("uuid.gd").v4_rng(get_rng(item))
```